### PR TITLE
Fixes for PREDICT mode

### DIFF
--- a/fetal_brain_segmentation_mri/reader.py
+++ b/fetal_brain_segmentation_mri/reader.py
@@ -84,7 +84,8 @@ def read_fn(file_references, mode, params=None):
         images = np.expand_dims(img, axis=-1).astype(np.float32)
 
         if mode == tf.estimator.ModeKeys.PREDICT:
-            yield {'features': {'x': images}, 'labels': None}
+            yield {'features': {'x': images}, 'labels': {'y': np.array([0])}, 'sitk': img_sitk, 'img_id': img_id}
+            continue
 
         # Read the label nii with sitk
         lbl_fn = f[2]


### PR DESCRIPTION
reader.py
- continue keyword required to skip remaining code
- yielded dictionary still needs img_id and sitk pointer header to save
segmentation
- returning y as an np.array of ‘0’, np.expand_dims breaks on None type

deploy.py
- added arg function to switch between EVAL/PREDICT
- in PREDICT mode, dsc = -1